### PR TITLE
fix: exit `tmux` prefix mode after executing macro

### DIFF
--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -71,7 +71,7 @@
             = <&macro_press &kp LCTRL>
             , <&macro_tap &kp B>
             , <&macro_release &kp LCTRL>
-            , <&macro_tap &kp BACKSLASH>
+            , <&macro_tap &kp BACKSLASH &kp ESC &kp I>
             ;
       )
       ZMK_MACRO(tmux_split_h,
@@ -81,7 +81,7 @@
             = <&macro_press &kp LCTRL>
             , <&macro_tap &kp B>
             , <&macro_release &kp LCTRL>
-            , <&macro_tap &kp MINUS>
+            , <&macro_tap &kp MINUS &kp ESC &kp I>
             ;
       )
       ZMK_MACRO(tmux_zoom,


### PR DESCRIPTION
When firmware sends code for `ESC` it is also picked up by shell which gets executed and moves prompt to Normal mode instead of remaining in the INSERT mode. So we undo that with `&kp I` at the end of the macro tap